### PR TITLE
Trivial fix to the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module "network" {
 }
 
 data "azuread_group" "aks_cluster_admins" {
-  name = "AKS-cluster-admins"
+  display_name = "AKS-cluster-admins"
 }
 
 module "aks" {


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/group

`display_name` is a valid argument. `name` as in the Readme is invalid.

Fixes #150 



